### PR TITLE
Feature/logging

### DIFF
--- a/FsSql.nuspec
+++ b/FsSql.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FsSql</id>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <title>FsSql</title>
     <authors>Mauricio Scheffer</authors>
     <owners>Mauricio Scheffer</owners>

--- a/FsSql/AssemblyInfo.fs
+++ b/FsSql/AssemblyInfo.fs
@@ -4,8 +4,8 @@ open System.Reflection
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 
-[<assembly: AssemblyVersion("2.0.0.0")>]
-[<assembly: AssemblyFileVersion("2.0.0.0")>]
+[<assembly: AssemblyVersion("2.0.1.0")>]
+[<assembly: AssemblyFileVersion("2.0.1.0")>]
 [<assembly: AssemblyTitle("FsSql")>]
 [<assembly: AssemblyDescription("ADO.NET wrapper for F#")>]
 [<assembly: AssemblyProduct("FsSql")>]

--- a/FsSql/FsSql.fsproj
+++ b/FsSql/FsSql.fsproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{F2570DA4-5DF1-4D5E-9534-B3F55606B3B5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>FsSql</RootNamespace>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>    
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <AssemblyName>FsSql</AssemblyName>
     <Name>FsSql</Name>
     <TargetFrameworkProfile />
@@ -51,6 +51,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="FSharpTypeExtensions.fs" />
     <Compile Include="FSharpValueExtensions.fs" />
+    <Compile Include="Logging.fs" />
     <Compile Include="prelude.fs" />
     <Compile Include="AsyncExtensions.fs" />
     <Compile Include="OptionExtensions.fs" />
@@ -74,7 +75,7 @@
     <Reference Include="FSharp.Core" Condition="$(TargetFrameworkVersion) != 'v2.0'">
       <HintPath>..\packages\FSharp.Core.3.1.2.1\lib\net40\FSharp.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FSharp.Core, Version=2.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFrameworkVersion) == 'v2.0'">
+    <Reference Include="FSharp.Core" Condition="$(TargetFrameworkVersion) == 'v2.0'">
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/FsSql/Logging.fs
+++ b/FsSql/Logging.fs
@@ -1,0 +1,161 @@
+module FsSql.Logging
+
+open System
+
+/// The log levels specify the severity of the message.
+[<CustomEquality; CustomComparison>]
+type LogLevel =
+    /// The most verbose log level, more verbose than Debug.
+    | Verbose
+    /// Less verbose than Verbose, more verbose than Info
+    | Debug
+    /// Less verbose than Debug, more verbose than Warn
+    | Info
+    /// Less verbose than Info, more verbose than Error
+    | Warn
+    /// Less verbose than Warn, more verbose than Fatal
+    | Error
+    /// The least verbose level. Will only pass through fatal
+    /// log lines that cause the application to crash or become
+    /// unusable.
+    | Fatal
+    /// Convert the LogLevel to a string
+    override x.ToString () =
+        match x with
+        | Verbose -> "verbose"
+        | Debug -> "debug"
+        | Info -> "info"
+        | Warn -> "warn"
+        | Error -> "error"
+        | Fatal -> "fatal"
+
+    /// Converts the string passed to a Loglevel.
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member FromString str =
+        match str with
+        | "verbose" -> Verbose
+        | "debug" -> Debug
+        | "info" -> Info
+        | "warn" -> Warn
+        | "error" -> Error
+        | "fatal" -> Fatal
+        | _ -> Info
+
+    /// Turn the LogLevel into an integer
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    member x.ToInt () =
+        (function
+        | Verbose -> 1
+        | Debug -> 2
+        | Info -> 3
+        | Warn -> 4
+        | Error -> 5
+        | Fatal -> 6) x
+
+    /// Turn an integer into a LogLevel
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member FromInt i =
+        (function
+        | 1 -> Verbose
+        | 2 -> Debug
+        | 3 -> Info
+        | 4 -> Warn
+        | 5 -> Error
+        | 6 -> Fatal
+        | _ as i -> failwith "rank %i not available" i) i
+
+    static member op_LessThan (a, b) = (a :> IComparable<LogLevel>).CompareTo(b) < 0
+    static member op_LessThanOrEqual (a, b) = (a :> IComparable<LogLevel>).CompareTo(b) <= 0
+    static member op_GreaterThan (a, b) = (a :> IComparable<LogLevel>).CompareTo(b) > 0
+    static member op_GreaterThanOrEqual (a, b) = (a :> IComparable<LogLevel>).CompareTo(b) >= 0
+
+    override x.Equals other = (x :> IComparable).CompareTo other = 0
+
+    override x.GetHashCode () = x.ToInt ()
+
+    interface IComparable with
+        member x.CompareTo other =
+            match other with
+            | null -> 1
+            | :? LogLevel as tother ->
+                (x :> IComparable<LogLevel>).CompareTo tother
+            | _ -> failwith <| sprintf "invalid comparison %A to %A" x other
+
+    interface IComparable<LogLevel> with
+        member x.CompareTo other =
+            compare (x.ToInt()) (other.ToInt())
+
+    interface IEquatable<LogLevel> with
+        member x.Equals other =
+            x.ToInt() = other.ToInt()
+
+/// The number of ticks of the clock.
+type Ticks = int64
+
+/// When logging, write a log line like this with the source of your
+/// log line as well as a message and an optional exception.
+type LogLine =
+    {   /// the level that this log line has
+        level     : LogLevel
+        /// the source of the log line, e.g. 'ModuleName.FunctionName'
+        path      : string
+        /// the message that the application wants to log
+        message   : string
+        /// any key-value based data to log
+        data      : Map<string, obj>
+        /// timestamp when this log line was created, in utc ticks
+        timestamp : Ticks }
+
+/// The primary Logger abstraction that you can log data into
+type Logger =
+    abstract Verbose : (unit -> LogLine) -> unit
+    abstract Debug : (unit -> LogLine) -> unit
+    abstract Log : LogLine -> unit
+
+let NoopLogger =
+    { new Logger with
+        member x.Verbose f_line = ()
+        member x.Debug f_line = ()
+        member x.Log line = () }
+
+let private logger =
+    ref ((fun () -> DateTime.UtcNow.Ticks),
+          fun (name : string) -> NoopLogger)
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module LogLine =
+
+    let mk (clock : unit -> Ticks) path level data message =
+        { message   = message
+          level     = level
+          path      = path
+          data      = data
+          timestamp = clock () }
+
+    let message data message =
+        { message   = message
+          level     = Info
+          path      = ""
+          data      = data |> Map.ofList
+          timestamp = (!logger |> fst) () }
+
+    let sprintf data =
+        Printf.kprintf (message data)
+
+let configure (clock : unit -> Ticks) fLogger =
+    logger := (clock, fLogger)
+
+let getLoggerByName name =
+    (!logger |> snd) name
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Logger =
+
+    let log (logger : Logger) (line : LogLine) =
+        logger.Log line
+
+    let debug (logger : Logger) f_line =
+        logger.Debug f_line
+
+    let verbose (logger : Logger) f_line =
+        logger.Verbose f_line

--- a/FsSql/prelude.fs
+++ b/FsSql/prelude.fs
@@ -2,8 +2,11 @@ module FsSqlPrelude
 
 open System
 open Microsoft.FSharp.Reflection
+open FsSql.Logging
 
-let log s = () // printfn "%A: %s" DateTime.Now s
+let private logger = FsSql.Logging.getLoggerByName "FsSql"
+
+let log s = Logger.debug logger (fun _ -> LogLine.message [] s)
 let logf a = Printf.kprintf log a
 
 let inline internal isNull a = LanguagePrimitives.PhysicalEquality a null

--- a/README.textile
+++ b/README.textile
@@ -13,3 +13,26 @@ For general usage, see:
 * "A functional wrapper over ADO.NET":http://bugsquash.blogspot.com/2010/10/functional-wrapper-over-adonet.html
 * "A functional wrapper over ADO.NET part 2":http://bugsquash.blogspot.com/2010/10/functional-wrapper-over-adonet-part-2.html
 * "Sample code":https://github.com/mausch/FsSql/blob/master/FsSql.Tests/Samples.fsx
+
+Configuring logging:
+
+<pre><code>
+open System
+open System.Diagnostics
+
+open FsSql
+
+type MyLogger(name) =
+  interface Logging.Logger with
+    member x.Log line =
+      Debug.WriteLine (sprintf "%A" line)
+    member x.Debug fLine =
+      Debug.WriteLine (sprintf "%A" (fLine ()))
+    member x.Verbose fLine =
+      Debug.WriteLine (sprintf "%A" (fLine ()))
+
+Logging.configure (fun () -> DateTime.UtcNow.Ticks)
+                  (fun name -> new MyLogger(name))
+</code></pre>
+
+


### PR DESCRIPTION
Hiya,

A simple logging facade for the library.

The jest of it is that you don't evaluate the log statement unless you're logging at that level, but right now, I haven't switched any `log` or `logf` statements over to using the deferred logging with `Logger.debug` and `Logger.verbose` -- right now it will be what was there before - forced reflection based string interpolation with Printf.kprintf, and forced string instantiation.

An aside:

I can't run tests, because it's currently build with a Windows-only library for sqlite. I did have a discussion with the developer of the Sqlite library, who's open for a PR (basically) to make it work cross-platform.

MiTLS solves that by conditionally compiling `Mono.Data.Sqlite` in the `.fsproj` file.

See https://github.com/mausch/FsSql/issues/25